### PR TITLE
[codex] Bootstrap lamprep core models and manual registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository is a Python package for `lamprep`, a version-pinned LAMMPS input generator. Source code lives under `src/lamprep/`. Keep core models in `src/lamprep/specs.py`, CLI wiring in `src/lamprep/cli.py`, and versioned registry data under `src/lamprep/manual_registry/`. Put human-facing design and planning docs in `docs/superpowers/specs/` and `docs/superpowers/plans/`. Keep test plans in `docs/test-plans/`. Automated tests live in `tests/unit/` and `tests/integration/`.
+
+## Build, Test, and Development Commands
+
+- `python3 -m venv .venv` creates the local virtual environment.
+- `./.venv/bin/pip install -e ".[dev]"` installs the package and dev dependencies in editable mode.
+- `./.venv/bin/pytest -q` runs the full suite.
+- `./.venv/bin/pytest -q tests/unit/test_manual_registry.py` runs a focused unit slice.
+- `./.venv/bin/python -m lamprep` performs a quick CLI smoke check.
+
+Use the repo-local `.venv`; do not rely on system Python packages.
+
+## Coding Style & Naming Conventions
+
+Use Python 3.11+ style with 4-space indentation, explicit type hints, and small focused modules. Prefer `dataclass` models for structured data and keep public APIs narrow. Use snake_case for functions, variables, modules, and test names. Class names use CapWords. There is no formatter configured yet, so keep code PEP 8 aligned and avoid unnecessary abstraction.
+
+## Testing Guidelines
+
+Tests use `pytest`. Add unit tests for each new module and extend `tests/integration/scenarios_v1.json` plus integration tests when behavior crosses module boundaries. Test files should be named `test_<area>.py`, and test functions should start with `test_`. New logic should include at least one failing test first, then the minimal implementation to make it pass.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses short imperative commits such as `feat: add versioned manual registry loader` and `fix: make manual registries immutable`. Follow that pattern: `feat:`, `fix:`, `docs:`, or `test:` plus a concise summary. PRs should explain what changed, why, and how it was verified. Link the relevant issue or plan when available, and include the exact test commands you ran.
+
+## Agent-Specific Instructions
+
+Do not develop directly on `main`. Use an isolated git worktree and feature branch, then verify the branch and path before editing. Avoid exposing extra public API beyond what the plan or spec requires. Generated files such as `.venv/`, `.pytest_cache/`, and `*.egg-info/` should not be committed.

--- a/src/lamprep/__init__.py
+++ b/src/lamprep/__init__.py
@@ -1,5 +1,13 @@
 """lamprep package."""
 
-__all__ = ["__version__"]
+from .specs import ForceFieldSpec, OutputSpec, RunStage, SimulationSpec
+
+__all__ = [
+    "__version__",
+    "ForceFieldSpec",
+    "OutputSpec",
+    "RunStage",
+    "SimulationSpec",
+]
 
 __version__ = "0.1.0"

--- a/src/lamprep/manual_registry/__init__.py
+++ b/src/lamprep/manual_registry/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from lamprep.manual_registry.base import ManualRegistry
 from lamprep.manual_registry.v11Feb2026 import REGISTRY as REGISTRY_11FEB2026
 from lamprep.manual_registry.v29Aug2024 import REGISTRY as REGISTRY_29AUG2024
@@ -22,6 +24,12 @@ def get_supported_versions() -> list[str]:
 
 def get_registry(version: str) -> ManualRegistry:
     try:
-        return _REGISTRIES[version]
+        registry = _REGISTRIES[version]
     except KeyError as exc:
         raise ValueError(f"Unsupported LAMMPS version: {version}") from exc
+
+    return replace(
+        registry,
+        supported_workflows=dict(registry.supported_workflows),
+        citations=dict(registry.citations),
+    )

--- a/src/lamprep/manual_registry/__init__.py
+++ b/src/lamprep/manual_registry/__init__.py
@@ -6,23 +6,22 @@ from lamprep.manual_registry.v29Aug2024 import REGISTRY as REGISTRY_29AUG2024
 
 __all__ = [
     "ManualRegistry",
-    "REGISTRIES",
     "get_supported_versions",
     "get_registry",
 ]
 
-REGISTRIES: dict[str, ManualRegistry] = {
+_REGISTRIES: dict[str, ManualRegistry] = {
     "29Aug2024": REGISTRY_29AUG2024,
     "11Feb2026": REGISTRY_11FEB2026,
 }
 
 
 def get_supported_versions() -> list[str]:
-    return list(REGISTRIES)
+    return list(_REGISTRIES)
 
 
 def get_registry(version: str) -> ManualRegistry:
     try:
-        return REGISTRIES[version]
+        return _REGISTRIES[version]
     except KeyError as exc:
         raise ValueError(f"Unsupported LAMMPS version: {version}") from exc

--- a/src/lamprep/manual_registry/__init__.py
+++ b/src/lamprep/manual_registry/__init__.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from lamprep.manual_registry.base import ManualRegistry
+from lamprep.manual_registry.v11Feb2026 import REGISTRY as REGISTRY_11FEB2026
+from lamprep.manual_registry.v29Aug2024 import REGISTRY as REGISTRY_29AUG2024
+
+__all__ = [
+    "ManualRegistry",
+    "REGISTRIES",
+    "get_supported_versions",
+    "get_registry",
+]
+
+REGISTRIES: dict[str, ManualRegistry] = {
+    "29Aug2024": REGISTRY_29AUG2024,
+    "11Feb2026": REGISTRY_11FEB2026,
+}
+
+
+def get_supported_versions() -> list[str]:
+    return list(REGISTRIES)
+
+
+def get_registry(version: str) -> ManualRegistry:
+    try:
+        return REGISTRIES[version]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported LAMMPS version: {version}") from exc

--- a/src/lamprep/manual_registry/base.py
+++ b/src/lamprep/manual_registry/base.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ManualRegistry:
+    version: str
+    allowed_commands: tuple[str, ...]
+    allowed_pair_styles: tuple[str, ...]
+    supported_workflows: dict[str, tuple[str, ...]]
+    citations: dict[str, str]

--- a/src/lamprep/manual_registry/v11Feb2026.py
+++ b/src/lamprep/manual_registry/v11Feb2026.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from lamprep.manual_registry.base import ManualRegistry
+
+
+REGISTRY = ManualRegistry(
+    version="11Feb2026",
+    allowed_commands=(
+        "units",
+        "dimension",
+        "boundary",
+        "atom_style",
+        "read_data",
+        "lattice",
+        "create_box",
+        "create_atoms",
+        "pair_style",
+        "pair_coeff",
+        "velocity",
+        "timestep",
+        "fix nve",
+        "fix nvt",
+        "fix npt",
+        "fix deform",
+        "minimize",
+        "thermo",
+        "thermo_style",
+        "dump",
+        "run",
+    ),
+    allowed_pair_styles=("lj/cut", "eam", "eam/alloy"),
+    supported_workflows={
+        "minimize": ("force_field",),
+        "equilibrate_nve": ("force_field", "timestep", "run_length"),
+        "equilibrate_nvt": ("force_field", "temperature", "timestep", "run_length"),
+        "equilibrate_npt": ("force_field", "temperature", "pressure", "timestep", "run_length"),
+        "heat": ("force_field", "temperature_start", "temperature_stop", "timestep", "run_length"),
+        "cool": ("force_field", "temperature_start", "temperature_stop", "timestep", "run_length"),
+        "deform_tensile": ("force_field", "deformation_axis", "strain_rate", "timestep", "run_length"),
+    },
+    citations={
+        "Commands_structure": "https://docs.lammps.org/Commands_structure.html",
+        "minimize": "https://docs.lammps.org/minimize.html",
+        "fix_nh": "https://docs.lammps.org/fix_nh.html",
+        "fix_deform": "https://docs.lammps.org/fix_deform.html",
+        "pair_eam": "https://docs.lammps.org/pair_eam.html",
+    },
+)

--- a/src/lamprep/manual_registry/v29Aug2024.py
+++ b/src/lamprep/manual_registry/v29Aug2024.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from lamprep.manual_registry.base import ManualRegistry
+
+
+REGISTRY = ManualRegistry(
+    version="29Aug2024",
+    allowed_commands=(
+        "units",
+        "dimension",
+        "boundary",
+        "atom_style",
+        "read_data",
+        "pair_style",
+        "pair_coeff",
+        "velocity",
+        "timestep",
+        "fix nve",
+        "fix nvt",
+        "fix npt",
+        "minimize",
+        "thermo",
+        "thermo_style",
+        "dump",
+        "run",
+    ),
+    allowed_pair_styles=("lj/cut", "eam", "eam/alloy"),
+    supported_workflows={
+        "minimize": ("force_field",),
+        "equilibrate_nve": ("force_field", "timestep", "run_length"),
+        "equilibrate_nvt": ("force_field", "temperature", "timestep", "run_length"),
+        "equilibrate_npt": ("force_field", "temperature", "pressure", "timestep", "run_length"),
+        "heat": ("force_field", "temperature_start", "temperature_stop", "timestep", "run_length"),
+        "cool": ("force_field", "temperature_start", "temperature_stop", "timestep", "run_length"),
+    },
+    citations={
+        "Commands_structure": "https://docs.lammps.org/Commands_structure.html",
+    },
+)

--- a/src/lamprep/specs.py
+++ b/src/lamprep/specs.py
@@ -56,7 +56,7 @@ class SimulationSpec:
             "boundary": self.boundary,
             "atom_style": self.atom_style,
             "structure_reference": self.structure_reference,
-            "create_box": dict(self.create_box),
+            "create_box": copy.deepcopy(self.create_box),
             "force_field": {
                 "style": self.force_field.style,
                 "coefficients": list(self.force_field.coefficients),
@@ -70,7 +70,7 @@ class SimulationSpec:
                     "temperature_stop": stage.temperature_stop,
                     "pressure_start": stage.pressure_start,
                     "pressure_stop": stage.pressure_stop,
-                    "extras": dict(stage.extras),
+                    "extras": copy.deepcopy(stage.extras),
                 }
                 for stage in self.run_stages
             ],
@@ -96,7 +96,7 @@ class SimulationSpec:
             boundary=payload["boundary"],
             atom_style=payload["atom_style"],
             structure_reference=payload.get("structure_reference"),
-            create_box=dict(payload.get("create_box", {})),
+            create_box=copy.deepcopy(payload.get("create_box", {})),
             force_field=ForceFieldSpec(
                 style=force_field["style"],
                 coefficients=list(force_field["coefficients"]),

--- a/src/lamprep/specs.py
+++ b/src/lamprep/specs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
 import json
 from typing import Any
@@ -85,6 +86,7 @@ class SimulationSpec:
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "SimulationSpec":
+        force_field = payload["force_field"]
         return cls(
             lammps_version=payload["lammps_version"],
             workflow_type=payload["workflow_type"],
@@ -95,9 +97,28 @@ class SimulationSpec:
             atom_style=payload["atom_style"],
             structure_reference=payload.get("structure_reference"),
             create_box=dict(payload.get("create_box", {})),
-            force_field=ForceFieldSpec(**payload["force_field"]),
-            run_stages=[RunStage(**stage) for stage in payload["run_stages"]],
-            outputs=OutputSpec(**payload["outputs"]),
+            force_field=ForceFieldSpec(
+                style=force_field["style"],
+                coefficients=list(force_field["coefficients"]),
+            ),
+            run_stages=[
+                RunStage(
+                    stage_type=stage["stage_type"],
+                    steps=stage["steps"],
+                    timestep=stage["timestep"],
+                    temperature_start=stage.get("temperature_start"),
+                    temperature_stop=stage.get("temperature_stop"),
+                    pressure_start=stage.get("pressure_start"),
+                    pressure_stop=stage.get("pressure_stop"),
+                    extras=copy.deepcopy(stage.get("extras", {})),
+                )
+                for stage in payload["run_stages"]
+            ],
+            outputs=OutputSpec(
+                thermo_every=payload["outputs"]["thermo_every"],
+                dump_every=payload["outputs"].get("dump_every"),
+                dump_fields=list(payload["outputs"].get("dump_fields", [])),
+            ),
         )
 
     @classmethod

--- a/src/lamprep/specs.py
+++ b/src/lamprep/specs.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Any
+
+
+@dataclass(eq=True)
+class ForceFieldSpec:
+    style: str
+    coefficients: list[str]
+
+
+@dataclass(eq=True)
+class RunStage:
+    stage_type: str
+    steps: int
+    timestep: float
+    temperature_start: float | None = None
+    temperature_stop: float | None = None
+    pressure_start: float | None = None
+    pressure_stop: float | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(eq=True)
+class OutputSpec:
+    thermo_every: int
+    dump_every: int | None = None
+    dump_fields: list[str] = field(default_factory=list)
+
+
+@dataclass(eq=True)
+class SimulationSpec:
+    lammps_version: str
+    workflow_type: str
+    system_definition_mode: str
+    units: str
+    dimension: int
+    boundary: str
+    atom_style: str
+    force_field: ForceFieldSpec
+    run_stages: list[RunStage]
+    outputs: OutputSpec
+    structure_reference: str | None = None
+    create_box: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lammps_version": self.lammps_version,
+            "workflow_type": self.workflow_type,
+            "system_definition_mode": self.system_definition_mode,
+            "units": self.units,
+            "dimension": self.dimension,
+            "boundary": self.boundary,
+            "atom_style": self.atom_style,
+            "structure_reference": self.structure_reference,
+            "create_box": dict(self.create_box),
+            "force_field": {
+                "style": self.force_field.style,
+                "coefficients": list(self.force_field.coefficients),
+            },
+            "run_stages": [
+                {
+                    "stage_type": stage.stage_type,
+                    "steps": stage.steps,
+                    "timestep": stage.timestep,
+                    "temperature_start": stage.temperature_start,
+                    "temperature_stop": stage.temperature_stop,
+                    "pressure_start": stage.pressure_start,
+                    "pressure_stop": stage.pressure_stop,
+                    "extras": dict(stage.extras),
+                }
+                for stage in self.run_stages
+            ],
+            "outputs": {
+                "thermo_every": self.outputs.thermo_every,
+                "dump_every": self.outputs.dump_every,
+                "dump_fields": list(self.outputs.dump_fields),
+            },
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SimulationSpec":
+        return cls(
+            lammps_version=payload["lammps_version"],
+            workflow_type=payload["workflow_type"],
+            system_definition_mode=payload["system_definition_mode"],
+            units=payload["units"],
+            dimension=payload["dimension"],
+            boundary=payload["boundary"],
+            atom_style=payload["atom_style"],
+            structure_reference=payload.get("structure_reference"),
+            create_box=dict(payload.get("create_box", {})),
+            force_field=ForceFieldSpec(**payload["force_field"]),
+            run_stages=[RunStage(**stage) for stage in payload["run_stages"]],
+            outputs=OutputSpec(**payload["outputs"]),
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "SimulationSpec":
+        return cls.from_dict(json.loads(payload))

--- a/tests/unit/test_manual_registry.py
+++ b/tests/unit/test_manual_registry.py
@@ -1,20 +1,10 @@
 from __future__ import annotations
 
-import lamprep.manual_registry as manual_registry
 from lamprep.manual_registry import get_registry, get_supported_versions
 
 
 def test_supported_versions_are_explicit_and_ordered() -> None:
     assert get_supported_versions() == ["29Aug2024", "11Feb2026"]
-
-
-def test_package_exports_are_explicit() -> None:
-    assert manual_registry.__all__ == [
-        "ManualRegistry",
-        "REGISTRIES",
-        "get_supported_versions",
-        "get_registry",
-    ]
 
 
 def test_main_registry_exposes_deformation_workflow() -> None:

--- a/tests/unit/test_manual_registry.py
+++ b/tests/unit/test_manual_registry.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import lamprep.manual_registry as manual_registry
+from lamprep.manual_registry import get_registry, get_supported_versions
+
+
+def test_supported_versions_are_explicit_and_ordered() -> None:
+    assert get_supported_versions() == ["29Aug2024", "11Feb2026"]
+
+
+def test_package_exports_are_explicit() -> None:
+    assert manual_registry.__all__ == [
+        "ManualRegistry",
+        "REGISTRIES",
+        "get_supported_versions",
+        "get_registry",
+    ]
+
+
+def test_main_registry_exposes_deformation_workflow() -> None:
+    registry = get_registry("11Feb2026")
+    assert "deform_tensile" in registry.supported_workflows
+    assert "fix deform" in registry.allowed_commands
+
+
+def test_older_registry_is_narrower() -> None:
+    registry = get_registry("29Aug2024")
+    assert "deform_tensile" not in registry.supported_workflows
+
+
+def test_unsupported_version_raises_value_error() -> None:
+    try:
+        get_registry("unknown")
+    except ValueError as exc:
+        assert str(exc) == "Unsupported LAMMPS version: unknown"
+    else:
+        raise AssertionError("expected ValueError")

--- a/tests/unit/test_manual_registry.py
+++ b/tests/unit/test_manual_registry.py
@@ -25,3 +25,14 @@ def test_unsupported_version_raises_value_error() -> None:
         assert str(exc) == "Unsupported LAMMPS version: unknown"
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_registry_lookup_returns_isolated_mappings() -> None:
+    registry = get_registry("11Feb2026")
+    registry.supported_workflows["mutated"] = ("value",)
+    registry.citations["new"] = "https://example.com"
+
+    fresh_registry = get_registry("11Feb2026")
+
+    assert "mutated" not in fresh_registry.supported_workflows
+    assert "new" not in fresh_registry.citations

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -50,6 +50,10 @@ def test_simulation_spec_json_round_trip_and_defensive_copy() -> None:
         boundary="p p p",
         atom_style="atomic",
         structure_reference="system.data",
+        create_box={
+            "padding": 2.0,
+            "regions": [{"name": "core", "atoms": [1, 2, 3]}],
+        },
         force_field=ForceFieldSpec(
             style="eam/alloy",
             coefficients=["* * Ni.eam.alloy Ni"],
@@ -61,7 +65,10 @@ def test_simulation_spec_json_round_trip_and_defensive_copy() -> None:
                 timestep=0.001,
                 temperature_start=300.0,
                 temperature_stop=300.0,
-                extras={"temperature_damp": 0.1},
+                extras={
+                    "temperature_damp": 0.1,
+                    "thermostat": {"chain": [1, 2, 3]},
+                },
             )
         ],
         outputs=OutputSpec(
@@ -81,9 +88,25 @@ def test_simulation_spec_json_round_trip_and_defensive_copy() -> None:
     copied = SimulationSpec.from_dict(payload)
 
     payload["force_field"]["coefficients"].append("new-coefficient")
-    payload["run_stages"][0]["extras"]["temperature_damp"] = 0.2
+    payload["run_stages"][0]["extras"]["thermostat"]["chain"].append(4)
+    payload["create_box"]["regions"][0]["atoms"].append(4)
     payload["outputs"]["dump_fields"].append("vx")
 
     assert copied.force_field.coefficients == ["* * Ni.eam.alloy Ni"]
-    assert copied.run_stages[0].extras == {"temperature_damp": 0.1}
+    assert copied.run_stages[0].extras == {
+        "temperature_damp": 0.1,
+        "thermostat": {"chain": [1, 2, 3]},
+    }
     assert copied.outputs.dump_fields == ["id", "type", "x", "y", "z"]
+    assert copied.create_box == {
+        "padding": 2.0,
+        "regions": [{"name": "core", "atoms": [1, 2, 3]}],
+    }
+    assert spec.create_box == {
+        "padding": 2.0,
+        "regions": [{"name": "core", "atoms": [1, 2, 3]}],
+    }
+    assert spec.run_stages[0].extras == {
+        "temperature_damp": 0.1,
+        "thermostat": {"chain": [1, 2, 3]},
+    }

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -1,0 +1,38 @@
+from lamprep.specs import ForceFieldSpec, OutputSpec, RunStage, SimulationSpec
+
+
+def test_simulation_spec_round_trip() -> None:
+    spec = SimulationSpec(
+        lammps_version="11Feb2026",
+        workflow_type="equilibrate_nvt",
+        system_definition_mode="read_data",
+        units="metal",
+        dimension=3,
+        boundary="p p p",
+        atom_style="atomic",
+        structure_reference="system.data",
+        force_field=ForceFieldSpec(
+            style="eam/alloy",
+            coefficients=["* * Ni.eam.alloy Ni"],
+        ),
+        run_stages=[
+            RunStage(
+                stage_type="equilibrate_nvt",
+                steps=1000,
+                timestep=0.001,
+                temperature_start=300.0,
+                temperature_stop=300.0,
+                extras={"temperature_damp": 0.1},
+            )
+        ],
+        outputs=OutputSpec(
+            thermo_every=100,
+            dump_every=500,
+            dump_fields=["id", "type", "x", "y", "z"],
+        ),
+    )
+
+    payload = spec.to_dict()
+    restored = SimulationSpec.from_dict(payload)
+
+    assert restored == spec

--- a/tests/unit/test_specs.py
+++ b/tests/unit/test_specs.py
@@ -1,4 +1,6 @@
-from lamprep.specs import ForceFieldSpec, OutputSpec, RunStage, SimulationSpec
+import json
+
+from lamprep import ForceFieldSpec, OutputSpec, RunStage, SimulationSpec
 
 
 def test_simulation_spec_round_trip() -> None:
@@ -36,3 +38,52 @@ def test_simulation_spec_round_trip() -> None:
     restored = SimulationSpec.from_dict(payload)
 
     assert restored == spec
+
+
+def test_simulation_spec_json_round_trip_and_defensive_copy() -> None:
+    spec = SimulationSpec(
+        lammps_version="11Feb2026",
+        workflow_type="equilibrate_nvt",
+        system_definition_mode="read_data",
+        units="metal",
+        dimension=3,
+        boundary="p p p",
+        atom_style="atomic",
+        structure_reference="system.data",
+        force_field=ForceFieldSpec(
+            style="eam/alloy",
+            coefficients=["* * Ni.eam.alloy Ni"],
+        ),
+        run_stages=[
+            RunStage(
+                stage_type="equilibrate_nvt",
+                steps=1000,
+                timestep=0.001,
+                temperature_start=300.0,
+                temperature_stop=300.0,
+                extras={"temperature_damp": 0.1},
+            )
+        ],
+        outputs=OutputSpec(
+            thermo_every=100,
+            dump_every=500,
+            dump_fields=["id", "type", "x", "y", "z"],
+        ),
+    )
+
+    json_payload = spec.to_json()
+    restored = SimulationSpec.from_json(json_payload)
+
+    assert restored == spec
+    assert json.loads(json_payload) == spec.to_dict()
+
+    payload = spec.to_dict()
+    copied = SimulationSpec.from_dict(payload)
+
+    payload["force_field"]["coefficients"].append("new-coefficient")
+    payload["run_stages"][0]["extras"]["temperature_damp"] = 0.2
+    payload["outputs"]["dump_fields"].append("vx")
+
+    assert copied.force_field.coefficients == ["* * Ni.eam.alloy Ni"]
+    assert copied.run_stages[0].extras == {"temperature_damp": 0.1}
+    assert copied.outputs.dump_fields == ["id", "type", "x", "y", "z"]


### PR DESCRIPTION
## What changed
- add the initial lamprep project scaffold and design/test-plan docs
- add canonical simulation spec models with round-trip serialization coverage
- add versioned manual registries for 29Aug2024 and 11Feb2026
- add AGENTS.md contributor guidelines

## Current project status
This PR does not make lamprep fully usable yet. It establishes the core data model and registry foundation.

Implemented in this branch:
- repository scaffold and editable Python package setup
- SimulationSpec and related dataclasses
- version-pinned manual registry loading
- unit tests for specs and manual registries

Not implemented yet:
- workflow catalog and validator
- renderer
- natural-language interpretation and clarification
- application orchestration
- real CLI flow
- end-to-end integration behavior

## Verification
- ./.venv/bin/pytest -q tests/unit/test_specs.py
- ./.venv/bin/pytest -q tests/unit/test_manual_registry.py
- ./.venv/bin/pytest -q

## Notes
- this is intentionally a draft because the product is still in foundation stage rather than feature-complete stage